### PR TITLE
Fix test in Path.t to work with Carp 1.25

### DIFF
--- a/t/Path.t
+++ b/t/Path.t
@@ -500,7 +500,7 @@ SKIP: {
         $dir = catdir($dir_stem, 'aad');
         stderr_like(
             sub {make_path($dir, {user => $max_user, group => $max_group})},
-            qr{\Aunable to map $max_user to a uid, ownership not changed: .* at \S+ line \d+
+            qr{\Aunable to map $max_user to a uid, ownership not changed: .* at \S+ line \d+[.]+
 unable to map $max_group to a gid, group ownership not changed: .* at \S+ line \d+\b},
             "created a directory not owned by $max_user:$max_group..."
         );

--- a/t/Path.t
+++ b/t/Path.t
@@ -500,7 +500,7 @@ SKIP: {
         $dir = catdir($dir_stem, 'aad');
         stderr_like(
             sub {make_path($dir, {user => $max_user, group => $max_group})},
-            qr{\Aunable to map $max_user to a uid, ownership not changed: .* at \S+ line \d+[.]?
+            qr{\Aunable to map $max_user to a uid, ownership not changed: .* at \S+ line \d+\.?
 unable to map $max_group to a gid, group ownership not changed: .* at \S+ line \d+\b},
             "created a directory not owned by $max_user:$max_group..."
         );

--- a/t/Path.t
+++ b/t/Path.t
@@ -500,7 +500,7 @@ SKIP: {
         $dir = catdir($dir_stem, 'aad');
         stderr_like(
             sub {make_path($dir, {user => $max_user, group => $max_group})},
-            qr{\Aunable to map $max_user to a uid, ownership not changed: .* at \S+ line \d+[.]+
+            qr{\Aunable to map $max_user to a uid, ownership not changed: .* at \S+ line \d+[.]?
 unable to map $max_group to a gid, group ownership not changed: .* at \S+ line \d+\b},
             "created a directory not owned by $max_user:$max_group..."
         );


### PR DESCRIPTION
Carp adds a period to its output as of version 1.25, but that wasn't accepted by the stderr_like regex.
